### PR TITLE
Feature/retry mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # mu-auth-sudo
-NPM package for a sparql client for mu.semte.ch that overrules access rights in queries through a mu-auth-sudo header.
+NPM package for a SPARQL client for mu.semte.ch that overrules access rights in queries through a mu-auth-sudo header.
 
 ## Usage
 ```
@@ -13,7 +13,7 @@ import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
 
 //Examples
 
-// To run a normal query
+// To run a regular query
 
 const queryString = `SELECT * FROM { GRAPH ?g { ?s ?p ?o. } } LIMIT 1`;
 await query(queryString);
@@ -24,9 +24,11 @@ const updateString = `INSERT DATA { GRAPH <http://foo> { <http://bar> <http://ba
 const extraHeaders = { 'mu-call-scope-id':  'http://foo/bar', 'other-info'; 'hello' };
 await update(updateString, extraHeaders);
 
-// With custom sparqlEndpoint (this should be exceptional, make sure you know what you're doing)
+// With custom connection options (this should be exceptional, make sure you know what you're doing)
 
-await update(updateString, extraHeaders, 'http://the.sparql.endpoint/sparql');
+const connectionOptions = { sparqlEndpoint: 'http://the.custom.endpoint/sparql', mayRetry: true };
+
+await update(updateString, extraHeaders, connectionOptions);
 ```
 
 ## Logging
@@ -39,3 +41,13 @@ The verbosity of logging can be configured as in the [javascript template](https
 - `DEBUG_AUTH_HEADERS`: Debugging of [mu-authorization](https://github.com/mu-semtech/mu-authorization) access-control related headers (default `true`)
 
 Following values are considered true: [`"true"`, `"TRUE"`, `"1"`].
+
+## Retrying
+You can tweak system-wide retry parameters. These should be considered internal, but tweaking them may help in extreme scenarios. Use with extreme caution.
+
+- `SUDO_QUERY_RETRY`: System-wide configuration to enable the retry-mechanism (default `'false'`).
+                        Warning: this overules eventual source-code specifications (i.e. `connectionOptions = { mayRetry: false }`), so make sure you know what you're doing.
+- `SUDO_QUERY_RETRY_MAX_ATTEMPTS`: Specfiy the number of max retry attempts (default: 5)
+- `SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES`: Specify what returned HTTP status from the database are allowed for retry. (default: `''`). Overriding this list should be considered case by case.
+- `SUDO_QUERY_RETRY_FOR_CONNECTION_ERRORS`: Specify what connection errors are allowed for retry. (default: `'ECONNRESET,ETIMEDOUT,EAI_AGAIN'`)
+- `SUDO_QUERY_RETRY_TIMEOUT_INCREMENT_FACTOR`: Specify the factor applied to the timeout before the next attempt. Check implementation to see how it is calculated. (default: `'0.3'`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lblod/mu-auth-sudo",
-  "version": "0.6.0-rc.0",
+  "version": "0.6.0-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lblod/mu-auth-sudo",
-  "version": "0.5.1",
+  "version": "0.6.0-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lblod/mu-auth-sudo",
-  "version": "0.6.0-rc.0",
+  "version": "0.6.0-rc.1",
   "description": "this package provides an alternative sparql client for the mu-javascript-template that has sudo rights.",
   "main": "dist/auth-sudo.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lblod/mu-auth-sudo",
-  "version": "0.5.1",
+  "version": "0.6.0-rc.0",
   "description": "this package provides an alternative sparql client for the mu-javascript-template that has sudo rights.",
   "main": "dist/auth-sudo.js",
   "scripts": {

--- a/src/auth-sudo.js
+++ b/src/auth-sudo.js
@@ -5,10 +5,10 @@ import env from 'env-var';
 const LOG_SPARQL_QUERIES = process.env.LOG_SPARQL_QUERIES != undefined ? env.get('LOG_SPARQL_QUERIES').asBool() : env.get('LOG_SPARQL_ALL').asBool();
 const LOG_SPARQL_UPDATES = process.env.LOG_SPARQL_UPDATES != undefined ? env.get('LOG_SPARQL_UPDATES').asBool() : env.get('LOG_SPARQL_ALL').asBool();
 const DEBUG_AUTH_HEADERS = env.get('DEBUG_AUTH_HEADERS').asBool();
-const RETRY = env.get('QUERY_RETRY').default('false').asBool();
-const RETRY_MAX_ATTEMPTS = env.get('QUERY_RETRY_MAX_ATTEMPTS').default('5').asInt();
-const RETRY_ON_HTTP_STATUS_CODES = env.get('QUERY_RETRY_ON_HTTP_STATUS_CODES').default('').asArray();
-const RETRY_ON_CONNECTION_ERRORS = env.get('QUERY_RETRY_ON_CONNECTION_ERRORS').default('ECONNRESET,ETIMEDOUT,EAI_AGAIN').asArray();
+const RETRY = env.get('SUDO_QUERY_RETRY').default('false').asBool();
+const RETRY_MAX_ATTEMPTS = env.get('SUDO_QUERY_RETRY_MAX_ATTEMPTS').default('5').asInt();
+const RETRY_FOR_HTTP_STATUS_CODES = env.get('SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES').default('').asArray();
+const RETRY_FOR_CONNECTION_ERRORS = env.get('SUDO_QUERY_RETRY_FOR_CONNECTION_ERRORS').default('ECONNRESET,ETIMEDOUT,EAI_AGAIN').asArray();
 
 function sudoSparqlClient( extraHeaders = {}, sparqlEndpoint) {
   sparqlEndpoint = sparqlEndpoint || process.env.MU_SPARQL_ENDPOINT;
@@ -90,9 +90,9 @@ function mayRetry(error, attempt) {
   let mayRetry = false;
 
   if(RETRY && attempt < RETRY_MAX_ATTEMPTS) {
-    if(error.code && RETRY_ON_CONNECTION_ERRORS.includes(error.code)) {
+    if(error.code && RETRY_FOR_CONNECTION_ERRORS.includes(error.code)) {
       mayRetry = true;
-    } else if(error.httpStatus & RETRY_ON_HTTP_STATUS_CODES.includes(`${error.httpStatus}`)) {
+    } else if(error.httpStatus & RETRY_FOR_HTTP_STATUS_CODES.includes(`${error.httpStatus}`)) {
       mayRetry = true;
     }
   }

--- a/src/auth-sudo.js
+++ b/src/auth-sudo.js
@@ -5,6 +5,8 @@ import env from 'env-var';
 const LOG_SPARQL_QUERIES = process.env.LOG_SPARQL_QUERIES != undefined ? env.get('LOG_SPARQL_QUERIES').asBool() : env.get('LOG_SPARQL_ALL').asBool();
 const LOG_SPARQL_UPDATES = process.env.LOG_SPARQL_UPDATES != undefined ? env.get('LOG_SPARQL_UPDATES').asBool() : env.get('LOG_SPARQL_ALL').asBool();
 const DEBUG_AUTH_HEADERS = env.get('DEBUG_AUTH_HEADERS').asBool();
+
+// The following configuration options are considered optional, but may be overriden as a temporary workaround for issues. Thus, a last resort.
 const RETRY = env.get('SUDO_QUERY_RETRY').default('false').asBool();
 const RETRY_MAX_ATTEMPTS = env.get('SUDO_QUERY_RETRY_MAX_ATTEMPTS').default('5').asInt();
 const RETRY_FOR_HTTP_STATUS_CODES = env.get('SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES').default('').asArray();

--- a/src/auth-sudo.js
+++ b/src/auth-sudo.js
@@ -92,7 +92,7 @@ function mayRetry(error, attempt) {
   if(RETRY && attempt < RETRY_MAX_ATTEMPTS) {
     if(error.code && RETRY_FOR_CONNECTION_ERRORS.includes(error.code)) {
       mayRetry = true;
-    } else if(error.httpStatus & RETRY_FOR_HTTP_STATUS_CODES.includes(`${error.httpStatus}`)) {
+    } else if(error.httpStatus && RETRY_FOR_HTTP_STATUS_CODES.includes(`${error.httpStatus}`)) {
       mayRetry = true;
     }
   }

--- a/src/auth-sudo.js
+++ b/src/auth-sudo.js
@@ -70,7 +70,11 @@ async function executeRawQuery(queryString, extraHeaders = {}, connectionOptions
 
       return await executeRawQuery(queryString, extraHeaders, connectionOptions, attempt);
 
-    } else throw ex;
+    } else {
+      console.log(`Failed Query:
+                  ${queryString}`);
+      throw ex;
+    }
   }
 
 }

--- a/src/auth-sudo.js
+++ b/src/auth-sudo.js
@@ -11,6 +11,7 @@ const RETRY = env.get('SUDO_QUERY_RETRY').default('false').asBool();
 const RETRY_MAX_ATTEMPTS = env.get('SUDO_QUERY_RETRY_MAX_ATTEMPTS').default('5').asInt();
 const RETRY_FOR_HTTP_STATUS_CODES = env.get('SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES').default('').asArray();
 const RETRY_FOR_CONNECTION_ERRORS = env.get('SUDO_QUERY_RETRY_FOR_CONNECTION_ERRORS').default('ECONNRESET,ETIMEDOUT,EAI_AGAIN').asArray();
+const RETRY_TIMEOUT_INCREMENT_FACTOR = env.get('SUDO_QUERY_RETRY_TIMEOUT_INCREMENT_FACTOR').default('0.3').asFloat();
 
 function sudoSparqlClient( extraHeaders = {}, connectionOptions = {} ) {
 
@@ -114,7 +115,7 @@ function mayRetry(error, attempt, connectionOptions = {}) {
 
 function nextAttemptTimeout(attempt) {
   //expected to be milliseconds
-  return Math.round(Math.exp(0.3 * attempt + 10));
+  return Math.round(Math.exp(RETRY_TIMEOUT_INCREMENT_FACTOR * attempt + 10));
 }
 
 const exports = {

--- a/src/auth-sudo.js
+++ b/src/auth-sudo.js
@@ -8,6 +8,7 @@ const DEBUG_AUTH_HEADERS = env.get('DEBUG_AUTH_HEADERS').asBool();
 const RETRY = env.get('QUERY_RETRY').default('false').asBool();
 const RETRY_MAX_ATTEMPTS = env.get('QUERY_RETRY_MAX_ATTEMPTS').default('5').asInt();
 const RETRY_ON_HTTP_STATUS_CODES = env.get('QUERY_RETRY_ON_HTTP_STATUS_CODES').default('').asArray();
+const RETRY_ON_CONNECTION_ERRORS = env.get('QUERY_RETRY_ON_CONNECTION_ERRORS').default('ECONNRESET,ETIMEDOUT,EAI_AGAIN').asArray();
 
 function sudoSparqlClient( extraHeaders = {}, sparqlEndpoint = process.env.MU_SPARQL_ENDPOINT ) {
   let options = {
@@ -88,7 +89,7 @@ function mayRetry(error, attempt) {
   let mayRetry = false;
 
   if(RETRY && attempt < RETRY_MAX_ATTEMPTS) {
-    if(error.code == 'ECONNRESET') {
+    if(error.code && RETRY_ON_CONNECTION_ERRORS.includes(error.code)) {
       mayRetry = true;
     } else if(error.httpStatus & RETRY_ON_HTTP_STATUS_CODES.includes(`${error.httpStatus}`)) {
       mayRetry = true;

--- a/src/auth-sudo.js
+++ b/src/auth-sudo.js
@@ -5,6 +5,9 @@ import env from 'env-var';
 const LOG_SPARQL_QUERIES = process.env.LOG_SPARQL_QUERIES != undefined ? env.get('LOG_SPARQL_QUERIES').asBool() : env.get('LOG_SPARQL_ALL').asBool();
 const LOG_SPARQL_UPDATES = process.env.LOG_SPARQL_UPDATES != undefined ? env.get('LOG_SPARQL_UPDATES').asBool() : env.get('LOG_SPARQL_ALL').asBool();
 const DEBUG_AUTH_HEADERS = env.get('DEBUG_AUTH_HEADERS').asBool();
+const RETRY = env.get('QUERY_RETRY').default('false').asBool();
+const RETRY_MAX_ATTEMPTS = env.get('QUERY_RETRY_MAX_ATTEMPTS').default('5').asInt();
+const RETRY_ON_HTTP_STATUS_CODES = env.get('QUERY_RETRY_ON_HTTP_STATUS_CODES').default('404').asArray();
 
 function sudoSparqlClient( extraHeaders = {}, sparqlEndpoint ) {
 
@@ -36,14 +39,31 @@ function sudoSparqlClient( extraHeaders = {}, sparqlEndpoint ) {
   return new SparqlClient(sparqlEndpoint, options);
 }
 
-async function executeRawQuery(queryString, extraHeaders = {}, sparqlEndpoint) {
+async function executeRawQuery(queryString, extraHeaders = {}, sparqlEndpoint, attempt = 0) {
 
   if( LOG_SPARQL_QUERIES ) {
     console.log(queryString);
   }
 
-  const response = await sudoSparqlClient(extraHeaders, sparqlEndpoint).query(queryString).executeRaw();
-  return maybeParseJSON(response.body);
+  try {
+
+    const response = await sudoSparqlClient(extraHeaders, sparqlEndpoint).query(queryString).executeRaw();
+    return maybeParseJSON(response.body);
+
+  } catch(ex) {
+
+    if(mayRetry(ex, attempt)) {
+
+      attempt += 1;
+
+      const sleepTime = nextAttemptTimeout(attempt);
+      console.log(`Sleeping ${sleepTime} ms before next attempt`);
+      await new Promise(r => setTimeout(r, sleepTime));
+
+      return await executeRawQuery(queryString, extraHeaders, sparqlEndpoint, attempt);
+
+    } else throw ex;
+  }
 
 }
 
@@ -62,6 +82,30 @@ function maybeParseJSON(body) {
   } catch (ex) {
     return null;
   }
+}
+
+function mayRetry(error, attempt) {
+
+  console.log(`Checking retry allowed for error: ${error} and attempt: ${attempt}`);
+
+  let mayRetry = false;
+
+  if(RETRY && attempt < RETRY_MAX_ATTEMPTS) {
+    if(error.code == 'ECONNRESET') {
+      mayRetry = true;
+    } else if(RETRY_ON_HTTP_STATUS_CODES.includes(`${error.statusCode}`)) {
+      mayRetry = true;
+    }
+  }
+
+  console.log(`Retry allowed? ${mayRetry}`);
+
+  return mayRetry;
+}
+
+function nextAttemptTimeout(attempt) {
+  //expected to be milliseconds
+  return Math.round(Math.exp(0.3 * attempt + 10));
 }
 
 const exports = {

--- a/src/auth-sudo.js
+++ b/src/auth-sudo.js
@@ -57,7 +57,7 @@ async function executeRawQuery(queryString, extraHeaders = {}, connectionOptions
 
   } catch(ex) {
 
-    if(mayRetry(ex, attempt)) {
+    if(mayRetry(ex, attempt, connectionOptions)) {
 
       attempt += 1;
 
@@ -89,13 +89,15 @@ function maybeParseJSON(body) {
   }
 }
 
-function mayRetry(error, attempt) {
+function mayRetry(error, attempt, connectionOptions = {}) {
 
   console.log(`Checking retry allowed for error: ${error} and attempt: ${attempt}`);
 
   let mayRetry = false;
 
-  if(RETRY && attempt < RETRY_MAX_ATTEMPTS) {
+  if( !(RETRY || connectionOptions.mayRetry) ) {
+    mayRetry = false;
+  } else if(attempt < RETRY_MAX_ATTEMPTS) {
     if(error.code && RETRY_FOR_CONNECTION_ERRORS.includes(error.code)) {
       mayRetry = true;
     } else if(error.httpStatus && RETRY_FOR_HTTP_STATUS_CODES.includes(`${error.httpStatus}`)) {

--- a/src/auth-sudo.js
+++ b/src/auth-sudo.js
@@ -90,7 +90,7 @@ function mayRetry(error, attempt) {
   if(RETRY && attempt < RETRY_MAX_ATTEMPTS) {
     if(error.code == 'ECONNRESET') {
       mayRetry = true;
-    } else if(RETRY_ON_HTTP_STATUS_CODES.includes(`${error.statusCode}`)) {
+    } else if(error.httpStatus & RETRY_ON_HTTP_STATUS_CODES.includes(`${error.httpStatus}`)) {
       mayRetry = true;
     }
   }

--- a/src/auth-sudo.js
+++ b/src/auth-sudo.js
@@ -7,7 +7,7 @@ const LOG_SPARQL_UPDATES = process.env.LOG_SPARQL_UPDATES != undefined ? env.get
 const DEBUG_AUTH_HEADERS = env.get('DEBUG_AUTH_HEADERS').asBool();
 const RETRY = env.get('QUERY_RETRY').default('false').asBool();
 const RETRY_MAX_ATTEMPTS = env.get('QUERY_RETRY_MAX_ATTEMPTS').default('5').asInt();
-const RETRY_ON_HTTP_STATUS_CODES = env.get('QUERY_RETRY_ON_HTTP_STATUS_CODES').default('404').asArray();
+const RETRY_ON_HTTP_STATUS_CODES = env.get('QUERY_RETRY_ON_HTTP_STATUS_CODES').default('').asArray();
 
 function sudoSparqlClient( extraHeaders = {}, sparqlEndpoint ) {
 


### PR DESCRIPTION
Included an optional and configurable retry mechanism.

Sometimes, execution of queries may fail for technical
reasons, often related to the stack getting overloaded. In these cases,
it might make sense to just wait a little and retry again.

The conditions for retry are narrowly defined, by default, but may be configured at run time.
The type of conditions for retry are now connection errors and some httpErrors. These could expand over time.