### PR TITLE
Add alternative client interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,42 @@ const hmmm = firstBinding.banana
 const {value, type} = hmmm
 
 ```
+## Alternative client
+
+Exported under `@lblod/mu-auth-sudo/client` is an alternative interface to the same query and update methods, aimed at ease-of-use without needing to stay compatible with the familiar mu-helper patterns.
+
+It exports 3 ways of using the client:
+
+### `sparql[Select|Ask|Construct|Describe|Update]`
+
+These are simple wrappers around the `querySudo` and `updateSudo` methods.
+In contrast to the methods they wrap, they take the `extraHeaders` argument inside the `connectionOptions` object, leading to a slightly cleaner invocation when you want to provide connectionOptions, but don't need any extra headers.
+
+Additionally, by splitting the methods over the various sparql verbs, they eliminate the need for specifying the generic type parameter (except for the select method)
+
+### `mk[Select|Ask|Construct|Describe|Update]`
+
+It's common to need the same connectionOptions for every invocation, especially the `sparqlEndpoint` setting. 
+These builder methods allow you to make a preconfigured version of each of the sparql methods.
+The preconfigured methods still allow overriding their options.
+
+### `sparqlClient`
+
+Wraps the above 5 builder methods in a single object, allowing you to preconfigure all 5 methods at once.
+This makes it easy to use this library for multiple sparql endpoints in the same project, cause it eliminates the need to pass the sparqlEndpoint to every invocation, and keeps things organized.
+
+e.g.:
+
+```ts
+const fooClient = sparqlClient({sparqlEndpoint: 'http://foo.com/sparql'});
+fooClient.select("SELECT * WHERE {?s ?p ?v.}");
+fooClient.update("INSERT DATA {<a> <b> <c>.}")
+
+//etc
+
+const barClient = sparqlClient({sparqlEndpoint: 'http://bar.com/sparql'});
+barClient.select("SELECT * WHERE {?s ?p ?v.}", {authUser: "exceptionalOverride"})
+```
 
 ## Logging
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,16 @@
   "description": "this package provides an alternative sparql client for the mu-javascript-template that has sudo rights.",
   "main": "dist/auth-sudo.js",
   "types": "dist/auth-sudo.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/auth-sudo.d.ts",
+      "default": "./dist/auth-sudo.js"
+    },
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.js"
+    }
+  },
   "scripts": {
     "build": "tsc",
     "prepare": "npm run build",

--- a/src/auth-sudo.ts
+++ b/src/auth-sudo.ts
@@ -13,6 +13,7 @@ const LOG_SPARQL_ALL : string = env.get('LOG_SPARQL_ALL').default('true').asStri
 const LOG_SPARQL_QUERIES : boolean = env.get('LOG_SPARQL_QUERIES').default(LOG_SPARQL_ALL).asBool();
 const LOG_SPARQL_UPDATES : boolean = env.get('LOG_SPARQL_UPDATES').default(LOG_SPARQL_ALL).asBool();
 
+
 const DEBUG_AUTH_HEADERS : boolean = env.get('DEBUG_AUTH_HEADERS').default('false').asBool();
 // The following configuration options are optional and best left at the default values, but may be overriden as a temporary workaround for issues. Thus, a last resort.
 const RETRY = env.get('SUDO_QUERY_RETRY').default('false').asBool();

--- a/src/client.ts
+++ b/src/client.ts
@@ -25,41 +25,41 @@ export async function sparqlUpdate(queryStr: string, opts?: ClientOptions) {
 }
 
 export function mkSelect(presetOpts?: ClientOptions) { 
-  return function (queryStr:string, opts?: ClientOptions) {
+  return (queryStr:string, opts?: ClientOptions) => {
     return sparqlSelect(queryStr, {...presetOpts, ...opts});
   }
 }
 
 export function mkAsk(presetOpts?: ClientOptions) { 
-  return function (queryStr:string, opts?: ClientOptions) {
+  return (queryStr:string, opts?: ClientOptions) => {
     return sparqlAsk(queryStr, {...presetOpts, ...opts});
   }
 }
 export function mkConstruct(presetOpts?: ClientOptions) { 
-  return function (queryStr:string, opts?: ClientOptions) {
+  return (queryStr:string, opts?: ClientOptions) => {
     return sparqlConstruct(queryStr, {...presetOpts, ...opts});
   }
 }
 export function mkDescribe(presetOpts?: ClientOptions) { 
-  return function (queryStr:string, opts?: ClientOptions) {
+  return (queryStr:string, opts?: ClientOptions) => {
     return sparqlDescribe(queryStr, {...presetOpts, ...opts});
   }
 }
 export function mkUpdate(presetOpts?: ClientOptions) { 
-  return function (queryStr:string, opts?: ClientOptions) {
+  return (queryStr:string, opts?: ClientOptions) => {
     return sparqlUpdate(queryStr, {...presetOpts, ...opts});
   }
 }
 /**
-  * Create a bundle of sparql query functions with preconfigured options. Each function still allows for all its connectionOptions to be overridden.
-  * This allows for a consumer to easily make multiple clients for different endpoints, without having to explicitly pass the endpoint for every invocation.
-  *
-  * Usage example: 
-  * ```ts
-  * const fooClient = sparqlClient({sparqlEndpoint: 'http://foo.com/sparql'})
-  * const result = fooClient.select('SELECT * WHERE {?s ?p ?v.}')
-  * ```
-  */
+ * Create a bundle of sparql query functions with preconfigured options. Each function still allows for all its connectionOptions to be overridden.
+ * This allows for a consumer to easily make multiple clients for different endpoints, without having to explicitly pass the endpoint for every invocation.
+ *
+ * Usage example: 
+ * ```ts
+ * const fooClient = sparqlClient({sparqlEndpoint: 'http://foo.com/sparql'})
+ * const result = fooClient.select('SELECT * WHERE {?s ?p ?v.}')
+ * ```
+ */
 export function sparqlClient(presetOpts?: ClientOptions) {
   return {
     select: mkSelect(presetOpts),

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,72 @@
+import { querySudo, SPARQLQueryConfig, updateSudo, type ConnectionOptions } from './auth-sudo'
+
+export type ClientOptions = ConnectionOptions & {extraHeaders?: Record<string, string>} 
+async function doQuery<C extends SPARQLQueryConfig = string[]>(queryStr: string, opts?: ClientOptions) {
+  return querySudo<C>(queryStr, opts?.extraHeaders, opts);
+}
+export function sparqlSelect<C extends string[]>(queryStr: string, opts?: ClientOptions) {
+  return doQuery<C>(queryStr, opts);
+}
+
+export function sparqlAsk(queryStr: string, opts?: ClientOptions) {
+  return doQuery<'ask'>(queryStr, opts);
+}
+
+export async function sparqlConstruct(queryStr: string, opts?: ClientOptions) {
+  return doQuery<'construct'>(queryStr, opts);
+}
+
+export async function sparqlDescribe(queryStr: string, opts?: ClientOptions) {
+  return doQuery<'describe'>(queryStr, opts);
+}
+
+export async function sparqlUpdate(queryStr: string, opts?: ClientOptions) {
+  return updateSudo(queryStr, opts?.extraHeaders, opts)
+}
+
+export function mkSelect(presetOpts?: ClientOptions) { 
+  return function (queryStr:string, opts?: ClientOptions) {
+    return sparqlSelect(queryStr, {...presetOpts, ...opts});
+  }
+}
+
+export function mkAsk(presetOpts?: ClientOptions) { 
+  return function (queryStr:string, opts?: ClientOptions) {
+    return sparqlAsk(queryStr, {...presetOpts, ...opts});
+  }
+}
+export function mkConstruct(presetOpts?: ClientOptions) { 
+  return function (queryStr:string, opts?: ClientOptions) {
+    return sparqlConstruct(queryStr, {...presetOpts, ...opts});
+  }
+}
+export function mkDescribe(presetOpts?: ClientOptions) { 
+  return function (queryStr:string, opts?: ClientOptions) {
+    return sparqlDescribe(queryStr, {...presetOpts, ...opts});
+  }
+}
+export function mkUpdate(presetOpts?: ClientOptions) { 
+  return function (queryStr:string, opts?: ClientOptions) {
+    return sparqlUpdate(queryStr, {...presetOpts, ...opts});
+  }
+}
+/**
+  * Create a bundle of sparql query functions with preconfigured options. Each function still allows for all its connectionOptions to be overridden.
+  * This allows for a consumer to easily make multiple clients for different endpoints, without having to explicitly pass the endpoint for every invocation.
+  *
+  * Usage example: 
+  * ```ts
+  * const fooClient = sparqlClient({sparqlEndpoint: 'http://foo.com/sparql'})
+  * const result = fooClient.select('SELECT * WHERE {?s ?p ?v.}')
+  * ```
+  */
+export function sparqlClient(presetOpts?: ClientOptions) {
+  return {
+    select: mkSelect(presetOpts),
+    ask: mkAsk(presetOpts),
+    construct: mkConstruct(presetOpts),
+    describe: mkDescribe(presetOpts),
+    update: mkUpdate(presetOpts)
+  }
+}
+


### PR DESCRIPTION
Adds some convenience wrappers around the query and update methods to provide a more ergonomic interface, especially in consumers which heavily make use of the explicit `sparqlEndpoint` option in the connectionOptions, but it should be useful for everyone.

It's completely independent from the existing api, so no breaking changes